### PR TITLE
Remove red box around links and move appendix after references

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -17,6 +17,7 @@
 
 \usepackage[hyphens]{url}
 \usepackage{hyperref}
+\hypersetup{hidelinks}
 \usepackage{subfig}
 \usepackage{hhline}
 \usepackage{amsmath}
@@ -128,13 +129,14 @@ Acks.
 \chapter{Introduction}
 \input{introduction}
 
-\chapter*{Appendix}
-\input{appendix}
-
 \backmatter
 
 \bibliographystyle{apalike}
 \bibliography{bibliography}
+
+\chapter*{Appendix}
+\input{appendix}
+
 
 \end{document}
 \endinput

--- a/main.tex
+++ b/main.tex
@@ -134,7 +134,14 @@ Acks.
 \bibliographystyle{apalike}
 \bibliography{bibliography}
 
-\chapter*{Appendix}
+\newcommand\mainmatterWithoutReset
+ {\edef\temppagenumber{\arabic{page}}%
+  \mainmatter
+  \setcounter{page}{\temppagenumber}%
+ }
+\mainmatterWithoutReset
+
+\appendix
 \input{appendix}
 
 


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting. -->
This PR addresses comment @munkm made to me about removing the red boxes around hyper-linked elements. As you can see from the changes, I've added the line:
`\hypersetup{hidelinks}`
which does just that.

I also noticed that @samgdotson had an old issue about the order of sections in the template. So I moved the appendix below the references in `main.tex`. As such, this PR closes #3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request. -->

- Issue: #3 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the
Review Checklist before they begin their review.
